### PR TITLE
Add some eslint rules for best practices

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -18,5 +18,11 @@
     "ecmaFeatures": {
       "jsx": true
     }
+  },
+  "rules": {
+    "eqeqeq": "error",
+    "no-invalid-this": "error",
+    "no-var": "error",
+    "radix": "error"
   }
 }

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -6,5 +6,11 @@
   },
   "parserOptions": { "ecmaVersion": 2018 },
   "extends": ["eslint:recommended", "plugin:jest/recommended", "prettier"],
-  "plugins": ["jest"]
+  "plugins": ["jest"],
+  "rules": {
+    "eqeqeq": "error",
+    "no-invalid-this": "error",
+    "no-var": "error",
+    "radix": "error"
+  }
 }


### PR DESCRIPTION
This PR aims to add a few eslint rules to reduce errors.

`eqeqeq`: use `===`, `!==`
`no-invalid-this`: disallow `this` outside of classes or class-like objects
`no-var`: use `let` or `const` instead of `var`
`radix`: parseInt must use radix - react build already shows a warning for this